### PR TITLE
Add no-bypass program and improve build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.10)
+project(det-bypass)
+
+if (NOT DEFINED __SERVER__)
+    message(FATAL_ERROR "Please specify the __SERVER__ compilation variable")
+endif ()
+add_definitions(-D__SERVER__=${__SERVER__})
+
+if (__SERVER__)
+    message(STATUS "Compiling for the server machine")
+else ()
+    message(STATUS "Compiling for the client machine")
+endif ()
+
+if (NOT DEFINED DEBUG)
+    set(DEBUG 0)
+endif ()
+add_definitions(-DDEBUG=${DEBUG})
+
+if (DEBUG)
+    message(STATUS "Compiling with debug information")
+endif ()
+
+add_subdirectory(no-bypass)
+add_subdirectory(rdma)
+add_subdirectory(xdp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(det-bypass)
 
-if (NOT DEFINED __SERVER__)
-    message(FATAL_ERROR "Please specify the __SERVER__ compilation variable")
-endif ()
-add_definitions(-D__SERVER__=${__SERVER__})
-
-if (__SERVER__)
-    message(STATUS "Compiling for the server machine")
-else ()
-    message(STATUS "Compiling for the client machine")
-endif ()
-
-if (NOT DEFINED DEBUG)
-    set(DEBUG 0)
-endif ()
-add_definitions(-DDEBUG=${DEBUG})
-
-if (DEBUG)
-    message(STATUS "Compiling with debug information")
-endif ()
+include({CMAKE_CURRENT_SOURCE_DIR}/config.cmake)
 
 add_subdirectory(no-bypass)
 add_subdirectory(rdma)

--- a/common/common.h
+++ b/common/common.h
@@ -18,6 +18,13 @@
 #define DEBUG 0
 #endif
 
+/**
+ * __SERVER__ is specified at compilation time by CMake.
+ */
+#ifndef __SERVER__
+#define __SERVER__ 0
+#endif
+
 #if DEBUG
 #define LOG(stream, fmt, ...)                 \
     do                                        \
@@ -80,7 +87,6 @@
 
 // Random magic number for pingpong packets
 #define PINGPONG_MAGIC 0x8badbeef
-
 
 struct pingpong_payload {
     __u32 id;

--- a/common/common.h
+++ b/common/common.h
@@ -19,10 +19,10 @@
 #endif
 
 /**
- * __SERVER__ is specified at compilation time by CMake.
+ * SERVER is specified at compilation time by CMake.
  */
-#ifndef __SERVER__
-#define __SERVER__ 0
+#ifndef SERVER
+#define SERVER 0
 #endif
 
 #if DEBUG

--- a/common/persistence.c
+++ b/common/persistence.c
@@ -120,7 +120,7 @@ int _persistence_init (persistence_agent_t *agent, const char *filename)
     return 0;
 }
 
-persistence_agent_t *persistence_init (const char *filename, uint8_t flags)
+persistence_agent_t *persistence_init (const char *filename, uint32_t flags)
 {
     persistence_agent_t *agent = malloc (sizeof (persistence_agent_t));
     agent->flags = flags;

--- a/common/persistence.c
+++ b/common/persistence.c
@@ -91,7 +91,7 @@ int _persistence_init (persistence_agent_t *agent, const char *filename)
         return -1;
     }
 
-    if (agent->flags & PERSISTENCE_F_MIN_MAX_LATENCY)
+    if (agent->flags & PERSISTENCE_M_MIN_MAX_LATENCY)
     {
         struct min_max_latency_data *aux = malloc (sizeof (struct min_max_latency_data));
         if (aux == NULL)

--- a/common/persistence.h
+++ b/common/persistence.h
@@ -16,14 +16,36 @@ enum persistence_output_flags {
 /**
  * Flags defining what should be persisted.
  */
-enum persistence_data_flags {
+enum persistence_measurement_flags {
     // Store all rounds timestamps. Default option.
-    PERSISTENCE_F_ALL_TIMESTAMPS = 1 << 2,
+    PERSISTENCE_M_ALL_TIMESTAMPS = 1 << 2,
     // Store rounds with minimum and maximum latency
-    PERSISTENCE_F_MIN_MAX_LATENCY = 1 << 3,
+    PERSISTENCE_M_MIN_MAX_LATENCY = 1 << 3,
     // TODO: Store rounds in buckets
-    PERSISTENCE_F_BUCKETS = 1 << 4,
+    PERSISTENCE_M_BUCKETS = 1 << 4,
 };
+
+/**
+ * Convert the index of the flag to the value of the flag.
+ * This function is useful when the user provides the index of the flag as an argument of the experiment program.
+ *
+ * @param value the index of the flag
+ * @return the value of the flag
+ */
+inline int pers_measurement_to_flag (const int value)
+{
+    switch (value)
+    {
+    case 0:
+        return PERSISTENCE_M_ALL_TIMESTAMPS;
+    case 1:
+        return PERSISTENCE_M_MIN_MAX_LATENCY;
+    case 2:
+        return PERSISTENCE_M_BUCKETS;
+    default:
+        return -1;
+    }
+}
 
 struct min_max_latency_data {
     uint64_t min;
@@ -41,9 +63,9 @@ typedef struct pers_base_data {
 
     /**
      * Auxiliary data, depending on the flags.
-     * - PERSISTENCE_F_ALL_TIMESTAMPS: NULL
-     * - PERSISTENCE_F_MIN_MAX_LATENCY: struct min_max_latency_data
-     * - PERSISTENCE_F_BUCKETS: struct bucket_data
+     * - PERSISTENCE_M_ALL_TIMESTAMPS: NULL
+     * - PERSISTENCE_M_MIN_MAX_LATENCY: struct min_max_latency_data
+     * - PERSISTENCE_M_BUCKETS: struct bucket_data
      */
     void *aux;
 } pers_base_data_t;

--- a/common/persistence.h
+++ b/common/persistence.h
@@ -9,8 +9,8 @@
 #include <sys/queue.h>
 
 enum persistence_output_flags {
-    PERSISTENCE_F_FILE = 1 << 0,
-    PERSISTENCE_F_STDOUT = 1 << 1,
+    PERSISTENCE_F_FILE = 1U << 0,
+    PERSISTENCE_F_STDOUT = 1U << 1,
 };
 
 /**
@@ -18,11 +18,11 @@ enum persistence_output_flags {
  */
 enum persistence_measurement_flags {
     // Store all rounds timestamps. Default option.
-    PERSISTENCE_M_ALL_TIMESTAMPS = 1 << 2,
+    PERSISTENCE_M_ALL_TIMESTAMPS = 1U << 2,
     // Store rounds with minimum and maximum latency
-    PERSISTENCE_M_MIN_MAX_LATENCY = 1 << 3,
+    PERSISTENCE_M_MIN_MAX_LATENCY = 1U << 3,
     // TODO: Store rounds in buckets
-    PERSISTENCE_M_BUCKETS = 1 << 4,
+    PERSISTENCE_M_BUCKETS = 1U << 4,
 };
 
 /**
@@ -83,7 +83,7 @@ typedef struct persistence_agent {
     /**
      * Flags passed to the initialization function.
      */
-    int flags;
+    uint32_t flags;
 
     /**
      * Write data to the persistence agent.
@@ -112,4 +112,4 @@ typedef struct persistence_agent {
  * @param filename the name of the file to store data
  * @return 0 on success, -1 on error
  */
-persistence_agent_t *persistence_init (const char *filename, uint8_t flags);
+persistence_agent_t *persistence_init (const char *filename, uint32_t flags);

--- a/config.cmake
+++ b/config.cmake
@@ -1,5 +1,6 @@
-# create a variable SERVER; if given in the command-line, the given value will be used; otherwise False will be used
-option(SERVER "Compile for the server machine" False)
+if (NOT DEFINED SERVER)
+    message(FATAL_ERROR "SERVER variable must be defined.")
+endif ()
 add_definitions(-DSERVER=${SERVER})
 
 if (SERVER)
@@ -8,7 +9,9 @@ else ()
     message(STATUS "Compiling for the client machine")
 endif ()
 
-option(DEBUG "Compile with debug information" False)
+if (NOT DEFINED DEBUG)
+    set(DEBUG 0)
+endif ()
 add_definitions(-DDEBUG=${DEBUG})
 
 if (DEBUG)

--- a/config.cmake
+++ b/config.cmake
@@ -1,0 +1,17 @@
+# create a variable SERVER; if given in the command-line, the given value will be used; otherwise False will be used
+option(SERVER "Compile for the server machine" False)
+add_definitions(-DSERVER=${SERVER})
+
+if (SERVER)
+    message(STATUS "Compiling for the server machine")
+else ()
+    message(STATUS "Compiling for the client machine")
+endif ()
+
+option(DEBUG "Compile with debug information" False)
+add_definitions(-DDEBUG=${DEBUG})
+
+if (DEBUG)
+    message(STATUS "Compiling with debug information")
+endif ()
+

--- a/no-bypass/CMakeLists.txt
+++ b/no-bypass/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10)
+project(no-bypass)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -g -Wall -Werror -Wextra -Wpedantic")
+
+if (NOT DEBUG)
+    set(DEBUG 0)
+endif ()
+add_definitions(-DDEBUG=${DEBUG})
+
+file(GLOB SOURCES src/*.c ../common/*.c)
+
+add_executable(no-bypass ${SOURCES} main.c)

--- a/no-bypass/CMakeLists.txt
+++ b/no-bypass/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(no-bypass)
 
+include(${CMAKE_CURRENT_SOURCE_DIR}/../config.cmake)
+
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -g -Wall -Werror -Wextra -Wpedantic")
 

--- a/no-bypass/CMakeLists.txt
+++ b/no-bypass/CMakeLists.txt
@@ -4,11 +4,6 @@ project(no-bypass)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -g -Wall -Werror -Wextra -Wpedantic")
 
-if (NOT DEBUG)
-    set(DEBUG 0)
-endif ()
-add_definitions(-DDEBUG=${DEBUG})
-
 file(GLOB SOURCES src/*.c ../common/*.c)
 
 add_executable(no-bypass ${SOURCES} main.c)

--- a/no-bypass/main.c
+++ b/no-bypass/main.c
@@ -147,12 +147,12 @@ int main (int argc, char **argv)
 
     start_server (iters);
 #else
-    int persistence_flag = PERSISTENCE_M_ALL_TIMESTAMPS;
+    uint32_t persistence_flag = PERSISTENCE_M_ALL_TIMESTAMPS;
 
     uint32_t iters = 0;
     uint64_t interval = 0;
     char *server_ip = NULL;
-    if (!nobypass_parse_args (argc, argv, &iters, &interval, &server_ip))
+    if (!nobypass_parse_args (argc, argv, &iters, &interval, &server_ip, &persistence_flag))
     {
         nobypass_print_usage (argv[0]);
         return EXIT_FAILURE;

--- a/no-bypass/main.c
+++ b/no-bypass/main.c
@@ -1,0 +1,187 @@
+#include "../common/common.h"
+#include "../common/net.h"
+#include "../common/persistence.h"
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#define PINGPONG_UDP_PORT 12345
+
+persistence_agent_t *persistence_agent;
+
+void usage (char *prog)
+{
+    // <prog> <ifname> <action>
+    fprintf (stderr, "Usage: %s <action> [extra arguments]\n", prog);
+    fprintf (stderr, "Actions:\n");
+    fprintf (stderr, "\t- start: start the pingpong experiment\n");
+    fprintf (stderr, "\t         on the server: %s start <# of packets>\n", prog);
+    fprintf (stderr, "\t         on the client: %s start <# of packets> <packets interval (ns)> <server IP>\n", prog);
+}
+
+int new_socket (void)
+{
+    int fd = socket (AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0)
+    {
+        PERROR ("socket");
+        return -1;
+    }
+
+    return fd;
+}
+
+struct sockaddr_in new_sockaddr (const char *ip, uint16_t port)
+{
+    struct sockaddr_in addr;
+    memset (&addr, 0, sizeof (addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons (port);
+    if (inet_pton (AF_INET, ip, &addr.sin_addr) <= 0)
+    {
+        PERROR ("inet_pton");
+        exit (-1);
+    }
+
+    return addr;
+}
+
+void start_server (uint32_t iters)
+{
+    LOG (stdout, "Starting server\n");
+    int socket = new_socket ();
+    // wait for the client to connect
+    struct sockaddr_in server_addr;
+    memset (&server_addr, 0, sizeof (server_addr));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons (PINGPONG_UDP_PORT);
+    server_addr.sin_addr.s_addr = htonl (INADDR_ANY);
+
+    int ret = bind (socket, (struct sockaddr *) &server_addr, sizeof (server_addr));
+    if (ret < 0)
+    {
+        PERROR ("bind");
+        return;
+    }
+
+    struct sockaddr_in client_addr;
+    socklen_t client_addr_len = sizeof (client_addr);
+    memset (&client_addr, 0, sizeof (client_addr));
+
+    uint8_t recv_buf[PACKET_SIZE];
+    uint32_t last_idx = 0;
+    while (last_idx < iters)
+    {
+        int ret = recvfrom (socket, recv_buf, PACKET_SIZE, 0, (struct sockaddr *) &client_addr, &client_addr_len);
+        uint64_t ts = get_time_ns ();
+        if (ret < 0)
+        {
+            PERROR ("recvfrom");
+            return;
+        }
+
+        struct pingpong_payload *payload = (struct pingpong_payload *) recv_buf;
+        payload->ts[1] = ts;
+
+        last_idx = max (last_idx, payload->id);
+
+        payload->ts[2] = get_time_ns ();
+        // send the packet back to the client
+        ret = sendto (socket, recv_buf, PACKET_SIZE, 0, (struct sockaddr *) &client_addr, sizeof (client_addr));
+        if (ret < 0)
+        {
+            PERROR ("sendto");
+            return;
+        }
+    }
+}
+
+int send_single_packet (char *buf, const int packet_idx, struct sockaddr_ll *addr, void *aux)
+{
+    int socket = *(int *) aux;
+    struct pingpong_payload *payload = (struct pingpong_payload *) buf;
+    *payload = new_pingpong_payload (packet_idx);
+    payload->ts[0] = get_time_ns ();
+
+    return sendto (socket, buf, PACKET_SIZE, 0, (struct sockaddr *) addr, sizeof (*addr));
+}
+
+void start_client (uint32_t iters, uint64_t interval, const char *server_ip)
+{
+    persistence_agent = persistence_init ("no-bypass.dat", 0);
+    if (!persistence_agent)
+    {
+        LOG (stderr, "Failed to initialize persistence agent\n");
+        return;
+    }
+
+    LOG (stdout, "Starting client\n");
+    int socket = new_socket ();
+    struct sockaddr_in server_addr = new_sockaddr (server_ip, PINGPONG_UDP_PORT);
+    uint8_t send_buf[PACKET_SIZE];
+    memset (send_buf, 0, PACKET_SIZE);
+    // passing a ref to the local socket should work fine since the current function will not return until the pingpong is finished.
+    start_sending_packets (iters, interval, (char *) send_buf, (struct sockaddr_ll *) &server_addr, send_single_packet, &socket);
+
+    uint8_t recv_buf[PACKET_SIZE];
+    uint32_t last_idx = 0;
+    while (last_idx < iters)
+    {
+        int ret = recvfrom (socket, recv_buf, PACKET_SIZE, 0, NULL, NULL);
+        if (ret < 0)
+        {
+            PERROR ("recv");
+            return;
+        }
+
+        struct pingpong_payload *payload = (struct pingpong_payload *) recv_buf;
+        payload->ts[3] = get_time_ns ();
+        persistence_agent->write (persistence_agent, payload);
+
+        last_idx = max (last_idx, payload->id);
+    }
+
+    close (socket);
+    persistence_agent->close (persistence_agent);
+}
+
+int main (int argc, char **argv)
+{
+    if (argc < 3)
+    {
+        usage (argv[0]);
+        return -1;
+    }
+
+    const char *action = argv[1];
+
+    if (strcmp (action, "start") != 0)
+    {
+        usage (argv[0]);
+        return -1;
+    }
+
+    const uint32_t iters = atoi (argv[2]);
+
+    bool is_server = true;
+    char *server_ip = NULL;
+    uint64_t interval = -1;
+    if (argc > 3)
+    {
+        is_server = false;
+        interval = atoll (argv[3]);
+        server_ip = argv[4];
+    }
+
+    if (is_server)
+        start_server (iters);
+    else
+        start_client (iters, interval, server_ip);
+
+    return 0;
+}

--- a/no-bypass/main.c
+++ b/no-bypass/main.c
@@ -135,7 +135,7 @@ void start_client (uint32_t iters, uint64_t interval, const char *server_ip)
 
 int main (int argc, char **argv)
 {
-#if __SERVER__
+#if SERVER
     uint32_t iters = 0;
     if (!nobypass_parse_args (argc, argv, &iters))
     {

--- a/no-bypass/src/args.c
+++ b/no-bypass/src/args.c
@@ -9,10 +9,11 @@ void nobypass_print_usage (char *prog)
 #else
 void nobypass_print_usage (char *prog)
 {
-    printf ("Usage: %s -p <packets> -i <interval> -s <server_ip>\n", prog);
+    printf ("Usage: %s -p <packets> -i <interval> -s <server_ip> [-m <measurement>]\n", prog);
     printf ("\t-p, --packets <packets>\tNumber of packets to process in the experiment.\n");
     printf ("\t-i, --interval <interval>\tInterval between each packet in nanoseconds.\n");
     printf ("\t-s, --server <server_ip>\tServer IP address.\n");
+    printf ("\t-m, --measurement <measurement>\tMeasurement to perform. 0: All Timestamps, 1: Min/Max latency, 2: Buckets.\n");
 }
 #endif
 
@@ -52,16 +53,17 @@ static struct option long_options[] = {
     {"interval", required_argument, 0, 'i'},
     {"server", required_argument, 0, 's'},
     {"help", no_argument, 0, 'h'},
+    {"measurement", required_argument, 0, 'm'},
     {0, 0, 0, 0}};
 
-bool nobypass_parse_args (int argc, char **argv, uint32_t *iters, uint64_t *interval, char **server_ip)
+bool nobypass_parse_args (int argc, char **argv, uint32_t *iters, uint64_t *interval, char **server_ip, uint32_t *pers_flags)
 {
     int opt;
     *iters = 0;
     *interval = 0;
     *server_ip = NULL;
 
-    while ((opt = getopt_long (argc, argv, "p:i:s:h", long_options, NULL)) != -1)
+    while ((opt = getopt_long (argc, argv, "p:i:s:hm:", long_options, NULL)) != -1)
     {
         switch (opt)
         {
@@ -76,6 +78,9 @@ bool nobypass_parse_args (int argc, char **argv, uint32_t *iters, uint64_t *inte
             break;
         case 'h':
             return false;
+        case 'm':
+            *pers_flags = pers_measurement_to_flag (atoi (optarg));
+            break;
         default:
             return false;
         }

--- a/no-bypass/src/args.c
+++ b/no-bypass/src/args.c
@@ -3,17 +3,21 @@
 #if __SERVER__
 void nobypass_print_usage (char *prog)
 {
+    printf ("==== Server Program ====\n");
     printf ("Usage: %s -p <packets>\n", prog);
     printf ("\t-p, --packets <packets>\tNumber of packets to process in the experiment.\n");
+    printf ("\nIf you want to run the client program, compile without -DSERVER flag.\n");
 }
 #else
 void nobypass_print_usage (char *prog)
 {
+    printf ("==== Client Program ====\n");
     printf ("Usage: %s -p <packets> -i <interval> -s <server_ip> [-m <measurement>]\n", prog);
     printf ("\t-p, --packets <packets>\tNumber of packets to process in the experiment.\n");
     printf ("\t-i, --interval <interval>\tInterval between each packet in nanoseconds.\n");
     printf ("\t-s, --server <server_ip>\tServer IP address.\n");
     printf ("\t-m, --measurement <measurement>\tMeasurement to perform. 0: All Timestamps, 1: Min/Max latency, 2: Buckets.\n");
+    printf ("\nIf you want to run the server program, compile with -DSERVER flag.\n");
 }
 #endif
 

--- a/no-bypass/src/args.c
+++ b/no-bypass/src/args.c
@@ -1,6 +1,6 @@
 #include "args.h"
 
-#if __SERVER__
+#if SERVER
 void nobypass_print_usage (char *prog)
 {
     printf ("==== Server Program ====\n");
@@ -21,7 +21,7 @@ void nobypass_print_usage (char *prog)
 }
 #endif
 
-#if __SERVER__
+#if SERVER
 static struct option long_options[] = {
     {"packets", required_argument, 0, 'p'},
     {"help", no_argument, 0, 'h'},

--- a/no-bypass/src/args.c
+++ b/no-bypass/src/args.c
@@ -1,0 +1,89 @@
+#include "args.h"
+
+#if __SERVER__
+void nobypass_print_usage (char *prog)
+{
+    printf ("Usage: %s -p <packets>\n", prog);
+    printf ("\t-p, --packets <packets>\tNumber of packets to process in the experiment.\n");
+}
+#else
+void nobypass_print_usage (char *prog)
+{
+    printf ("Usage: %s -p <packets> -i <interval> -s <server_ip>\n", prog);
+    printf ("\t-p, --packets <packets>\tNumber of packets to process in the experiment.\n");
+    printf ("\t-i, --interval <interval>\tInterval between each packet in nanoseconds.\n");
+    printf ("\t-s, --server <server_ip>\tServer IP address.\n");
+}
+#endif
+
+#if __SERVER__
+static struct option long_options[] = {
+    {"packets", required_argument, 0, 'p'},
+    {"help", no_argument, 0, 'h'},
+    {0, 0, 0, 0}};
+
+bool nobypass_parse_args (int argc, char **argv, uint32_t *iters)
+{
+    int opt;
+    *iters = 0;
+
+    while ((opt = getopt_long (argc, argv, "p:h", long_options, NULL)) != -1)
+    {
+        switch (opt)
+        {
+        case 'p':
+            *iters = atoi (optarg);
+            break;
+        case 'h':
+            return false;
+        default:
+            return false;
+        }
+    }
+
+    if (*iters == 0)
+        return false;
+
+    return true;
+}
+#else
+static struct option long_options[] = {
+    {"packets", required_argument, 0, 'p'},
+    {"interval", required_argument, 0, 'i'},
+    {"server", required_argument, 0, 's'},
+    {"help", no_argument, 0, 'h'},
+    {0, 0, 0, 0}};
+
+bool nobypass_parse_args (int argc, char **argv, uint32_t *iters, uint64_t *interval, char **server_ip)
+{
+    int opt;
+    *iters = 0;
+    *interval = 0;
+    *server_ip = NULL;
+
+    while ((opt = getopt_long (argc, argv, "p:i:s:h", long_options, NULL)) != -1)
+    {
+        switch (opt)
+        {
+        case 'p':
+            *iters = atoi (optarg);
+            break;
+        case 'i':
+            *interval = atoi (optarg);
+            break;
+        case 's':
+            *server_ip = optarg;
+            break;
+        case 'h':
+            return false;
+        default:
+            return false;
+        }
+    }
+
+    if (*iters == 0 || *interval == 0 || *server_ip == NULL)
+        return false;
+
+    return true;
+}
+#endif

--- a/no-bypass/src/args.h
+++ b/no-bypass/src/args.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "../../common/common.h"
+#include <getopt.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void nobypass_print_usage (char *prog);
+
+#if __SERVER__
+bool nobypass_parse_args (int argc, char **argv, uint32_t *iters);
+#else
+bool nobypass_parse_args (int argc, char **argv, uint32_t *iters, uint64_t *interval, char **server_ip);
+#endif

--- a/no-bypass/src/args.h
+++ b/no-bypass/src/args.h
@@ -11,7 +11,7 @@
 
 void nobypass_print_usage (char *prog);
 
-#if __SERVER__
+#if SERVER
 bool nobypass_parse_args (int argc, char **argv, uint32_t *iters);
 #else
 bool nobypass_parse_args (int argc, char **argv, uint32_t *iters, uint64_t *interval, char **server_ip, uint32_t *pers_flags);

--- a/no-bypass/src/args.h
+++ b/no-bypass/src/args.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../../common/common.h"
+#include "../../common/persistence.h"
 #include <getopt.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -13,5 +14,5 @@ void nobypass_print_usage (char *prog);
 #if __SERVER__
 bool nobypass_parse_args (int argc, char **argv, uint32_t *iters);
 #else
-bool nobypass_parse_args (int argc, char **argv, uint32_t *iters, uint64_t *interval, char **server_ip);
+bool nobypass_parse_args (int argc, char **argv, uint32_t *iters, uint64_t *interval, char **server_ip, uint32_t *pers_flags);
 #endif

--- a/rdma/CMakeLists.txt
+++ b/rdma/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
+project(rdma)
 
-project("rdma")
+include(${CMAKE_CURRENT_SOURCE_DIR}/../config.cmake)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -g -Wall -Werror -Wextra -Wpedantic")
 

--- a/rdma/CMakeLists.txt
+++ b/rdma/CMakeLists.txt
@@ -2,11 +2,6 @@ cmake_minimum_required(VERSION 3.10)
 
 project("rdma")
 
-if (NOT DEBUG)
-    set(DEBUG 0)
-endif ()
-add_definitions(-DDEBUG=${DEBUG})
-
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -g -Wall -Werror -Wextra -Wpedantic")
 
 link_libraries(ibverbs)

--- a/rdma/README.md
+++ b/rdma/README.md
@@ -54,11 +54,12 @@ our use case:
 
 ## Build
 
-The build process follows the same steps as for any CMake project:
+The build process follows the same steps as for any CMake project, with a variable IS_SERVER to indicate if the program
+is the server or the client.
 
 ```bash
 cd build
-cmake ..
+cmake -D __SERVER__=<0/1> ..
 make
 ```
 
@@ -66,7 +67,7 @@ There is the option to build the programs using a `DEBUG` mode, which has extra 
 
 ```bash
 cd build
-cmake -D DEBUG=1 ..
+cmake -D DEBUG=1 -D __SERVER__=<0/1> ..
 make
 ```
 
@@ -77,17 +78,19 @@ The programs require at least two nodes to run, one acting as the server and the
 The following example shows how to run the `ud_pingpong` experiment.
 
 First, the server must be started, which will wait a connection from a client:
+
 ```bash
-./ud_pingpong <ib device name> <port gid index> start <pingpong rounds>
+./ud_pingpong -d <ib device name> -g <port gid index> -p <pingpong rounds>
 # Example:
-# ./ud_pingpong rocep65s0f0 0 start 1000
+# ./ud_pingpong -d rocep65s0f0 -g 0 -p 1000
 ```
 
 Then, the client must be started, which will connect to the server and start the pingpong:
+
 ```bash
-./ud_pingpong <ib device name> <port gid index> start <pingpong rounds> <send interval> <server IP>
+./ud_pingpong -d <ib device name> -g <port gid index> -p <pingpong rounds> -i <send interval> -s <server IP>
 # Example:
-# ./ud_pingpong rocep65s0f0 0 start 1000 1000000 10.10.1.2
+# ./ud_pingpong -d rocep65s0f0 -g 0 -p 1000 -i 1000000 -s 10.10.1.2
 ```
 
 Note that the CLI interface was adapted to the other programs in the project and is different from the one in the
@@ -95,5 +98,7 @@ Note that the CLI interface was adapted to the other programs in the project and
 
 ## Results
 
-By default, the results of the experiments are saved in a file named after the transport type (e.g. `ud_pingpong` creates a file `ud.dat`).
-In the code, the "persistence agent" can be modified to print results to stdout, to a different file, or to store different information about the results.
+By default, the results of the experiments are saved in a file named after the transport type (e.g. `ud_pingpong`
+creates a file `ud.dat`).
+In the code, the "persistence agent" can be modified to print results to stdout, to a different file, or to store
+different information about the results.

--- a/rdma/README.md
+++ b/rdma/README.md
@@ -54,12 +54,12 @@ our use case:
 
 ## Build
 
-The build process follows the same steps as for any CMake project, with a variable IS_SERVER to indicate if the program
+The build process follows the same steps as for any CMake project, with a variable SERVER to indicate if the program
 is the server or the client.
 
 ```bash
 cd build
-cmake -D __SERVER__=<0/1> ..
+cmake -D SERVER=<0,1> ..
 make
 ```
 
@@ -67,7 +67,7 @@ There is the option to build the programs using a `DEBUG` mode, which has extra 
 
 ```bash
 cd build
-cmake -D DEBUG=1 -D __SERVER__=<0/1> ..
+cmake -D DEBUG=1 -D SERVER=<0,1> ..
 make
 ```
 

--- a/rdma/rc_pingpong.c
+++ b/rdma/rc_pingpong.c
@@ -12,6 +12,7 @@
 #include "../common/net.h"
 #include "../common/persistence.h"
 //#include "ccan/minmax.h"
+#include "src/args.h"
 #include "src/ib_net.h"
 #include "src/pingpong.h"
 
@@ -23,15 +24,6 @@
 
 // Priority (i.e. service level) for the traffic
 #define PRIORITY 0
-
-void usage (char *prog)
-{
-    fprintf (stderr, "Usage: %s <ib-device> <port-gid-idx> <action> [extra arguments]\n", prog);
-    fprintf (stderr, "Actions:\n");
-    fprintf (stderr, "\t- start: start the pingpong experiment\n");
-    fprintf (stderr, "\t         on the server: %s <ib-device> <port-gid-idx> start <# of packets>\n", prog);
-    fprintf (stderr, "\t         on the client: %s <ib-device> <port-gid-idx> start <# of packets> <packets interval (ns)> <server IP>\n", prog);
-}
 
 enum {
     PINGPONG_RECV_WRID = 1,// The receive work request ID
@@ -375,11 +367,11 @@ static int pp_post_recv (struct pingpong_context *ctx, int n)
     return i;
 }
 
-int parse_single_wc (struct pingpong_context *ctx, const bool is_server)
+int parse_single_wc (struct pingpong_context *ctx)
 {
     const enum ibv_wc_status status = ctx->cq->status;
     const uint64_t wr_id = ctx->cq->wr_id;
-    const uint64_t ts = ibv_wc_read_completion_ts (ctx->cq);
+    __attribute_maybe_unused__ const uint64_t ts = ibv_wc_read_completion_ts (ctx->cq);
 
     if (status != IBV_WC_SUCCESS)
     {
@@ -394,19 +386,16 @@ int parse_single_wc (struct pingpong_context *ctx, const bool is_server)
         break;
     case PINGPONG_RECV_WRID:
         LOG (stdout, "Received packet\n");
-        if (is_server)
-        {
-            memcpy (ctx->send_payload, ctx->recv_payload, sizeof (struct pingpong_payload));
-            ctx->send_payload->ts[1] = ts;
-            ctx->send_payload->ts[2] = get_time_ns ();
-            // In this case, using the ctx->buf is safe because the server has no send thread concurrently accessing it.
-            pp_post_send (ctx, NULL);
-        }
-        else
-        {
-            ctx->recv_payload->ts[3] = get_time_ns ();
-            persistence->write (persistence, ctx->recv_payload);
-        }
+#if __SERVER__
+        memcpy (ctx->send_payload, ctx->recv_payload, sizeof (struct pingpong_payload));
+        ctx->send_payload->ts[1] = ts;
+        ctx->send_payload->ts[2] = get_time_ns ();
+        // In this case, using the ctx->buf is safe because the server has no send thread concurrently accessing it.
+        pp_post_send (ctx, NULL);
+#else
+        ctx->recv_payload->ts[3] = get_time_ns ();
+        persistence->write (persistence, ctx->recv_payload);
+#endif
         if (--available_recv <= 1)
         {
             available_recv += pp_post_recv (ctx, RECEIVE_DEPTH - available_recv);
@@ -429,34 +418,31 @@ int parse_single_wc (struct pingpong_context *ctx, const bool is_server)
 
 int main (int argc, char **argv)
 {
-    if (argc < 5)
-    {
-        usage (argv[0]);
-        return 1;
-    }
-
-    char *ib_devname = argv[1];
-    int port_gid_idx = strtol (argv[2], NULL, 0);
-    char *action = argv[3];
-
-    if (strncmp (action, "start", 5) != 0)
-    {
-        usage (argv[0]);
-        return 1;
-    }
-
-    uint32_t iters = strtol (argv[4], NULL, 0);
-
-    bool is_server = true;
+    char *ib_devname = NULL;
+    int port_gid_idx = 0;
+    uint32_t iters = 0;
     uint64_t interval = 0;
     char *server_ip = NULL;
 
-    if (argc > 5)
+#if __SERVER__
+    if (!ib_parse_args (argc, argv, &ib_devname, &port_gid_idx, &iters))
     {
-        is_server = false;
-        interval = strtol (argv[5], NULL, 0);
-        server_ip = argv[6];
+        ib_print_usage (argv[0]);
+        return 1;
     }
+#else
+    if (!ib_parse_args (argc, argv, &ib_devname, &port_gid_idx, &iters, &interval, &server_ip))
+    {
+        ib_print_usage (argv[0]);
+        return 1;
+    }
+    persistence = persistence_init ("rc_pingpong.dat", PERSISTENCE_M_ALL_TIMESTAMPS);
+    if (!persistence)
+    {
+        fprintf (stderr, "Couldn't initialize persistence agent\n");
+        return 1;
+    }
+#endif
 
     srand48 (getpid () * time (NULL));
 
@@ -485,22 +471,12 @@ int main (int argc, char **argv)
     ib_print_node_info (&local_info);
 
     struct ib_node_info remote_info;
-    if (exchange_data (server_ip, is_server, sizeof (local_info), (uint8_t *) &local_info, (uint8_t *) &remote_info))
+    if (exchange_data (server_ip, __SERVER__, sizeof (local_info), (uint8_t *) &local_info, (uint8_t *) &remote_info))
     {
         fprintf (stderr, "Couldn't exchange data\n");
         return 1;
     }
     ib_print_node_info (&remote_info);
-
-    if (!is_server)// only client needs to print
-    {
-        persistence = persistence_init ("rc_pingpong.dat", PERSISTENCE_F_STDOUT);
-        if (!persistence)
-        {
-            fprintf (stderr, "Couldn't initialize persistence agent\n");
-            return 1;
-        }
-    }
 
     pp_ib_connect (ctx, IB_PORT, local_info.psn, IB_MTU, PRIORITY, &remote_info, port_gid_idx);
 
@@ -509,11 +485,10 @@ int main (int argc, char **argv)
     available_recv = pp_post_recv (ctx, RECEIVE_DEPTH);
 
     uint8_t *send_buffer = NULL;
-    if (!is_server)
-    {
 
-        start_sending_packets (iters, interval, (char *) ctx->send_buf, NULL, pp_send_single_packet, ctx);
-    }
+#if !__SERVER__
+    start_sending_packets (iters, interval, (char *) ctx->send_buf, NULL, pp_send_single_packet, ctx);
+#endif
 
     uint32_t recv_count, send_count;
     recv_count = send_count = 0;
@@ -533,7 +508,7 @@ int main (int argc, char **argv)
             return 1;
         }
 
-        ret = parse_single_wc (ctx, is_server);
+        ret = parse_single_wc (ctx);
         if (ret)
         {
             LOG (stdout, "Failed to parse WC\n");
@@ -544,7 +519,7 @@ int main (int argc, char **argv)
         ret = ibv_next_poll (ctx->cq);
         if (!ret)
         {
-            ret = parse_single_wc (ctx, is_server);
+            ret = parse_single_wc (ctx);
             if (!ret)
                 ++recv_count;
         }

--- a/rdma/rc_pingpong.c
+++ b/rdma/rc_pingpong.c
@@ -421,7 +421,6 @@ int main (int argc, char **argv)
     char *ib_devname = NULL;
     int port_gid_idx = 0;
     uint32_t iters = 0;
-    uint64_t interval = 0;
     char *server_ip = NULL;
 
 #if __SERVER__
@@ -431,12 +430,14 @@ int main (int argc, char **argv)
         return 1;
     }
 #else
-    if (!ib_parse_args (argc, argv, &ib_devname, &port_gid_idx, &iters, &interval, &server_ip))
+    uint64_t interval = 0;
+    uint32_t persistence_flags = PERSISTENCE_M_ALL_TIMESTAMPS;
+    if (!ib_parse_args (argc, argv, &ib_devname, &port_gid_idx, &iters, &interval, &server_ip, &persistence_flags))
     {
         ib_print_usage (argv[0]);
         return 1;
     }
-    persistence = persistence_init ("rc_pingpong.dat", PERSISTENCE_M_ALL_TIMESTAMPS);
+    persistence = persistence_init ("rc.dat", persistence_flags);
     if (!persistence)
     {
         fprintf (stderr, "Couldn't initialize persistence agent\n");

--- a/rdma/rc_pingpong.c
+++ b/rdma/rc_pingpong.c
@@ -386,7 +386,7 @@ int parse_single_wc (struct pingpong_context *ctx)
         break;
     case PINGPONG_RECV_WRID:
         LOG (stdout, "Received packet\n");
-#if __SERVER__
+#if SERVER
         memcpy (ctx->send_payload, ctx->recv_payload, sizeof (struct pingpong_payload));
         ctx->send_payload->ts[1] = ts;
         ctx->send_payload->ts[2] = get_time_ns ();
@@ -423,7 +423,7 @@ int main (int argc, char **argv)
     uint32_t iters = 0;
     char *server_ip = NULL;
 
-#if __SERVER__
+#if SERVER
     if (!ib_parse_args (argc, argv, &ib_devname, &port_gid_idx, &iters))
     {
         ib_print_usage (argv[0]);
@@ -472,7 +472,7 @@ int main (int argc, char **argv)
     ib_print_node_info (&local_info);
 
     struct ib_node_info remote_info;
-    if (exchange_data (server_ip, __SERVER__, sizeof (local_info), (uint8_t *) &local_info, (uint8_t *) &remote_info))
+    if (exchange_data (server_ip, SERVER, sizeof (local_info), (uint8_t *) &local_info, (uint8_t *) &remote_info))
     {
         fprintf (stderr, "Couldn't exchange data\n");
         return 1;
@@ -487,7 +487,7 @@ int main (int argc, char **argv)
 
     uint8_t *send_buffer = NULL;
 
-#if !__SERVER__
+#if !SERVER
     start_sending_packets (iters, interval, (char *) ctx->send_buf, NULL, pp_send_single_packet, ctx);
 #endif
 

--- a/rdma/src/args.c
+++ b/rdma/src/args.c
@@ -1,0 +1,111 @@
+#include "args.h"
+
+#if __SERVER__
+void ib_print_usage (char *prog)
+{
+    printf ("Usage: %s -d <ibname> -g <gidx> -p <packets>\n", prog);
+    printf ("\t-d, --dev <ibname>\tInterface to attach XDP program to.\n");
+    printf ("\t-g, --gidx <gidx>\tGroup index to attach XDP program to.\n");
+    printf ("\t-p, --packets <packets>\tNumber of packets to process in the experiment.\n");
+}
+#else
+void ib_print_usage (char *prog)
+{
+    printf ("Usage: %s -d <ibname> -g <gidx> -p <packets> -i <interval> -s <server_ip>\n", prog);
+    printf ("\t-d, --dev <ibname>\tInterface to attach XDP program to.\n");
+    printf ("\t-g, --gidx <gidx>\tGroup index to attach XDP program to.\n");
+    printf ("\t-p, --packets <packets>\tNumber of packets to process in the experiment.\n");
+    printf ("\t-i, --interval <interval>\tInterval between each packet in nanoseconds.\n");
+    printf ("\t-s, --server <server_ip>\tServer IP address.\n");
+}
+#endif
+
+#if __SERVER__
+static struct option long_options[] = {
+    {"dev", required_argument, 0, 'd'},
+    {"gidx", required_argument, 0, 'g'},
+    {"packets", required_argument, 0, 'p'},
+    {"help", no_argument, 0, 'h'},
+    {0, 0, 0, 0}};
+
+bool ib_parse_args (int argc, char **argv, char **ibname, int *gidx, uint32_t *iters)
+{
+    int opt;
+    *iters = 0;
+
+    while ((opt = getopt_long (argc, argv, "d:g:p:h", long_options, NULL)) != -1)
+    {
+        switch (opt)
+        {
+        case 'd':
+            *ibname = optarg;
+            break;
+        case 'g':
+            *gidx = atoi (optarg);
+            break;
+        case 'p':
+            *iters = atoi (optarg);
+            break;
+        case 'h':
+            return false;
+        default:
+            return false;
+        }
+    }
+
+    if (*iters == 0 || *ibname == NULL || *gidx < 0)
+        return false;
+
+    return true;
+}
+
+#else
+
+static struct option long_options[] = {
+    {"dev", required_argument, 0, 'd'},
+    {"gidx", required_argument, 0, 'g'},
+    {"packets", required_argument, 0, 'p'},
+    {"interval", required_argument, 0, 'i'},
+    {"server", required_argument, 0, 's'},
+    {"help", no_argument, 0, 'h'},
+    {0, 0, 0, 0}};
+
+bool ib_parse_args (int argc, char **argv, char **ibname, int *gidx, uint32_t *iters, uint64_t *interval, char **server_ip)
+{
+    int opt;
+    *iters = 0;
+    *interval = 0;
+    *server_ip = NULL;
+
+    while ((opt = getopt_long (argc, argv, "d:g:p:i:s:h", long_options, NULL)) != -1)
+    {
+        switch (opt)
+        {
+        case 'd':
+            *ibname = optarg;
+            break;
+        case 'g':
+            *gidx = atoi (optarg);
+            break;
+        case 'p':
+            *iters = atoi (optarg);
+            break;
+        case 'i':
+            *interval = atoi (optarg);
+            break;
+        case 's':
+            *server_ip = optarg;
+            break;
+        case 'h':
+            return false;
+        default:
+            return false;
+        }
+    }
+
+    if (*iters == 0 || *ibname == NULL || *gidx < 0)
+        return false;
+
+    return true;
+}
+#endif

--- a/rdma/src/args.c
+++ b/rdma/src/args.c
@@ -11,12 +11,13 @@ void ib_print_usage (char *prog)
 #else
 void ib_print_usage (char *prog)
 {
-    printf ("Usage: %s -d <ibname> -g <gidx> -p <packets> -i <interval> -s <server_ip>\n", prog);
+    printf ("Usage: %s -d <ibname> -g <gidx> -p <packets> -i <interval> -s <server_ip> [-m <measurement>]\n", prog);
     printf ("\t-d, --dev <ibname>\tInterface to attach XDP program to.\n");
     printf ("\t-g, --gidx <gidx>\tGroup index to attach XDP program to.\n");
     printf ("\t-p, --packets <packets>\tNumber of packets to process in the experiment.\n");
     printf ("\t-i, --interval <interval>\tInterval between each packet in nanoseconds.\n");
     printf ("\t-s, --server <server_ip>\tServer IP address.\n");
+    printf ("\t-m, --measurement <measurement>\tMeasurement to perform. 0: All Timestamps, 1: Min/Max latency, 2: Buckets.\n");
 }
 #endif
 
@@ -68,16 +69,17 @@ static struct option long_options[] = {
     {"interval", required_argument, 0, 'i'},
     {"server", required_argument, 0, 's'},
     {"help", no_argument, 0, 'h'},
+    {"measurement", required_argument, 0, 'm'},
     {0, 0, 0, 0}};
 
-bool ib_parse_args (int argc, char **argv, char **ibname, int *gidx, uint32_t *iters, uint64_t *interval, char **server_ip)
+bool ib_parse_args (int argc, char **argv, char **ibname, int *gidx, uint32_t *iters, uint64_t *interval, char **server_ip, uint32_t *pers_flags)
 {
     int opt;
     *iters = 0;
     *interval = 0;
     *server_ip = NULL;
 
-    while ((opt = getopt_long (argc, argv, "d:g:p:i:s:h", long_options, NULL)) != -1)
+    while ((opt = getopt_long (argc, argv, "d:g:p:i:s:hm:", long_options, NULL)) != -1)
     {
         switch (opt)
         {
@@ -98,6 +100,9 @@ bool ib_parse_args (int argc, char **argv, char **ibname, int *gidx, uint32_t *i
             break;
         case 'h':
             return false;
+        case 'm':
+            *pers_flags = pers_measurement_to_flag (atoi (optarg));
+            break;
         default:
             return false;
         }

--- a/rdma/src/args.c
+++ b/rdma/src/args.c
@@ -1,6 +1,6 @@
 #include "args.h"
 
-#if __SERVER__
+#if SERVER
 void ib_print_usage (char *prog)
 {
     printf ("==== Server Program ====\n");
@@ -25,7 +25,7 @@ void ib_print_usage (char *prog)
 }
 #endif
 
-#if __SERVER__
+#if SERVER
 static struct option long_options[] = {
     {"dev", required_argument, 0, 'd'},
     {"gidx", required_argument, 0, 'g'},

--- a/rdma/src/args.c
+++ b/rdma/src/args.c
@@ -3,14 +3,17 @@
 #if __SERVER__
 void ib_print_usage (char *prog)
 {
+    printf ("==== Server Program ====\n");
     printf ("Usage: %s -d <ibname> -g <gidx> -p <packets>\n", prog);
     printf ("\t-d, --dev <ibname>\tInterface to attach XDP program to.\n");
     printf ("\t-g, --gidx <gidx>\tGroup index to attach XDP program to.\n");
     printf ("\t-p, --packets <packets>\tNumber of packets to process in the experiment.\n");
+    printf ("\nIf you want to run the client program, compile without -DSERVER flag.\n");
 }
 #else
 void ib_print_usage (char *prog)
 {
+    printf ("==== Client Program ====\n");
     printf ("Usage: %s -d <ibname> -g <gidx> -p <packets> -i <interval> -s <server_ip> [-m <measurement>]\n", prog);
     printf ("\t-d, --dev <ibname>\tInterface to attach XDP program to.\n");
     printf ("\t-g, --gidx <gidx>\tGroup index to attach XDP program to.\n");
@@ -18,6 +21,7 @@ void ib_print_usage (char *prog)
     printf ("\t-i, --interval <interval>\tInterval between each packet in nanoseconds.\n");
     printf ("\t-s, --server <server_ip>\tServer IP address.\n");
     printf ("\t-m, --measurement <measurement>\tMeasurement to perform. 0: All Timestamps, 1: Min/Max latency, 2: Buckets.\n");
+    printf ("\nIf you want to run the server program, compile with -DSERVER flag.\n");
 }
 #endif
 

--- a/rdma/src/args.h
+++ b/rdma/src/args.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "../../common/common.h"
+#include <getopt.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void ib_print_usage (char *prog);
+
+#if __SERVER__
+bool ib_parse_args (int argc, char **argv, char **ibname, int *gidx, uint32_t *iters);
+#else
+bool ib_parse_args (int argc, char **argv, char **ibname, int *gidx, uint32_t *iters, uint64_t *interval, char **server_ip);
+#endif

--- a/rdma/src/args.h
+++ b/rdma/src/args.h
@@ -11,7 +11,7 @@
 
 void ib_print_usage (char *prog);
 
-#if __SERVER__
+#if SERVER
 bool ib_parse_args (int argc, char **argv, char **ibname, int *gidx, uint32_t *iters);
 #else
 bool ib_parse_args (int argc, char **argv, char **ibname, int *gidx, uint32_t *iters, uint64_t *interval, char **server_ip, uint32_t *pers_flags);

--- a/rdma/src/args.h
+++ b/rdma/src/args.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../../common/common.h"
+#include "../../common/persistence.h"
 #include <getopt.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -13,5 +14,5 @@ void ib_print_usage (char *prog);
 #if __SERVER__
 bool ib_parse_args (int argc, char **argv, char **ibname, int *gidx, uint32_t *iters);
 #else
-bool ib_parse_args (int argc, char **argv, char **ibname, int *gidx, uint32_t *iters, uint64_t *interval, char **server_ip);
+bool ib_parse_args (int argc, char **argv, char **ibname, int *gidx, uint32_t *iters, uint64_t *interval, char **server_ip, uint32_t *pers_flags);
 #endif

--- a/rdma/ud_pingpong.c
+++ b/rdma/ud_pingpong.c
@@ -458,9 +458,17 @@ int main (int argc, char **argv)
     }
 #else
     uint64_t interval = 0;
-    if (!ib_parse_args (argc, argv, &ib_devname, &port_gid_idx, &iters, &interval, &server_ip))
+    uint32_t persistence_flags = 0;
+    if (!ib_parse_args (argc, argv, &ib_devname, &port_gid_idx, &iters, &interval, &server_ip, &persistence_flags))
     {
         ib_print_usage (argv[0]);
+        return 1;
+    }
+
+    persistence_agent = persistence_init ("ud.dat", persistence_flags);
+    if (!persistence_agent)
+    {
+        LOG (stderr, "Failed to initialize persistence agent\n");
         return 1;
     }
 #endif

--- a/rdma/ud_pingpong.c
+++ b/rdma/ud_pingpong.c
@@ -484,7 +484,7 @@ int main (int argc, char **argv)
     }
 
     if (!is_server)
-        persistence_agent = persistence_init ("ud.dat", PERSISTENCE_F_ALL_TIMESTAMPS);
+        persistence_agent = persistence_init ("ud.dat", PERSISTENCE_M_ALL_TIMESTAMPS);
 
     LOG (stdout, "Server IP: %s\n", server_ip);
 

--- a/rdma/ud_pingpong.c
+++ b/rdma/ud_pingpong.c
@@ -348,7 +348,7 @@ int parse_single_wc (struct pingpong_context *ctx, struct ibv_wc wc)
 
         // Only the server needs to wait for the completion of a send operation in order to post the receive.
         // Since the client reads the content immediately and only once, the recv is posted immediatly because overwriting the buffer is not a problem.
-#if __SERVER__
+#if SERVER
         if (UNLIKELY (pp_post_recv (ctx, wc.wr_id - PINGPONG_SEND_WRID)))
         {
             LOG (stderr, "Couldn't post receive on queue_idx %lu\n", wc.wr_id - PINGPONG_SEND_WRID);
@@ -361,7 +361,7 @@ int parse_single_wc (struct pingpong_context *ctx, struct ibv_wc wc)
     // Recv WRID
     uint32_t queue_idx = wc.wr_id - PINGPONG_RECV_WRID;
     // LOG (stdout, "Received packet on queue_idx %d\n", queue_idx);
-#if __SERVER__
+#if SERVER
     // Make sure the send buffer is not being used by an outgoing packet.
     BUSY_WAIT (BITSET_TEST (ctx->pending_send, queue_idx));
     ctx->recv_payloads[queue_idx]->ts[1] = ts;
@@ -450,7 +450,7 @@ int main (int argc, char **argv)
     uint32_t iters = 0;
 
     char *server_ip = NULL;
-#if __SERVER__
+#if SERVER
     if (!ib_parse_args (argc, argv, &ib_devname, &port_gid_idx, &iters))
     {
         ib_print_usage (argv[0]);
@@ -500,7 +500,7 @@ int main (int argc, char **argv)
     }
     ib_print_node_info (&local_info);
 
-    if (exchange_data (server_ip, __SERVER__, sizeof (local_info), (uint8_t *) &local_info, (uint8_t *) &ctx->remote_info))
+    if (exchange_data (server_ip, SERVER, sizeof (local_info), (uint8_t *) &local_info, (uint8_t *) &ctx->remote_info))
     {
         fprintf (stderr, "Couldn't exchange data\n");
         pp_close_context (ctx);
@@ -527,7 +527,7 @@ int main (int argc, char **argv)
         }
     }
 
-#if !__SERVER__
+#if !SERVER
     start_sending_packets (iters, interval, (char *) ctx->send_buf, NULL, pp_send_single_packet, ctx);
 #endif
 

--- a/xdp/CMakeLists.txt
+++ b/xdp/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 
-project("xdp")
+project(xdp)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../config.cmake)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
@@ -20,5 +22,5 @@ file(GLOB SOURCES src/*.c ../common/*.c)
 add_executable(pp_poll ${SOURCES} pp_poll.c)
 add_dependencies(pp_poll pingpong)
 
-add_executable (pp_sock ${SOURCES} pp_sock.c)
+add_executable(pp_sock ${SOURCES} pp_sock.c)
 add_dependencies(pp_sock pingpong_xsk)

--- a/xdp/CMakeLists.txt
+++ b/xdp/CMakeLists.txt
@@ -16,11 +16,6 @@ link_libraries(bpf xdp)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -g -Wall -Werror -Wextra -Wpedantic")
 
-if (NOT DEBUG)
-    set(DEBUG 0)
-endif ()
-add_definitions(-DDEBUG=${DEBUG})
-
 file(GLOB SOURCES src/*.c ../common/*.c)
 add_executable(pp_poll ${SOURCES} pp_poll.c)
 add_dependencies(pp_poll pingpong)

--- a/xdp/pp_poll.c
+++ b/xdp/pp_poll.c
@@ -150,7 +150,7 @@ void start_pingpong (int ifindex, const char *server_ip, const uint32_t iters, _
     uint32_t src_ip = 0;
     uint32_t dest_ip = 0;
     LOG (stdout, "Exchanging addresses... ");
-    int ret = exchange_eth_ip_addresses (ifindex, server_ip, __SERVER__, src_mac, dest_mac, &src_ip, &dest_ip);
+    int ret = exchange_eth_ip_addresses (ifindex, server_ip, SERVER, src_mac, dest_mac, &src_ip, &dest_ip);
     if (UNLIKELY (ret < 0))
     {
         fprintf (stderr, "ERR: exchange_eth_ip_addresses failed\n");
@@ -183,7 +183,7 @@ void start_pingpong (int ifindex, const char *server_ip, const uint32_t iters, _
 
     struct sockaddr_ll sock_addr = build_sockaddr (ifindex, dest_mac);
 
-#if !__SERVER__
+#if !SERVER
     LOG (stdout, "Starting sender thread... ");
     start_sending_packets (iters, interval, buf, &sock_addr, send_packet, NULL);
     LOG (stdout, "OK\n");
@@ -210,7 +210,7 @@ void start_pingpong (int ifindex, const char *server_ip, const uint32_t iters, _
 #endif
     struct pingpong_payload *buf_payload = packet_payload (buf);
 
-#if __SERVER__
+#if SERVER
     while (current_id < iters)
     {
         next_map_idx = poll_next_payload (map_ptr, buf_payload, next_map_idx);
@@ -326,7 +326,7 @@ int main (int argc, char **argv)
     uint64_t interval = 0;
     char *server_ip = NULL;
 
-#if __SERVER__
+#if SERVER
     if (!xdp_parse_args (argc, argv, &ifname, &remove, &iters))
     {
         xdp_print_usage (argv[0]);

--- a/xdp/pp_poll.c
+++ b/xdp/pp_poll.c
@@ -333,13 +333,15 @@ int main (int argc, char **argv)
         return EXIT_FAILURE;
     }
 #else
-    if (!xdp_parse_args (argc, argv, &ifname, &remove, &iters, &interval, &server_ip))
+    uint32_t persistence_flags = PERSISTENCE_M_ALL_TIMESTAMPS;
+
+    if (!xdp_parse_args (argc, argv, &ifname, &remove, &iters, &interval, &server_ip, &persistence_flags))
     {
         xdp_print_usage (argv[0]);
         return EXIT_FAILURE;
     }
 
-    persistence = persistence_init (outfile, PERSISTENCE_M_ALL_TIMESTAMPS);
+    persistence = persistence_init (outfile, persistence_flags);
     if (!persistence)
     {
         fprintf (stderr, "ERR: persistence_init failed\n");

--- a/xdp/pp_sock.c
+++ b/xdp/pp_sock.c
@@ -30,6 +30,7 @@
 #include "../common/net.h"
 #include "../common/persistence.h"
 #include "../common/utils.h"
+#include "src/args.h"
 #include "src/xdp-loading.h"
 
 #define STATS_THREAD 0
@@ -48,26 +49,8 @@ static const char *sec_name = "xdp";
 static const char *pinpath = "/sys/fs/bpf/xdp_pingpong_xsk";
 static const char *mapname = "xsk_map";
 
-// Whether the current machine is the server or the client in the experiment.
-static bool is_server = false;
-
-static const char *outfile = "pingpong_xsk.dat";
+__attribute_maybe_unused__ static const char *outfile = "pingpong_xsk.dat";
 static persistence_agent_t *persistence_agent;
-
-/**
- * Prints instructions on how to use the program.
- *
- * @param prog the command that was run to execute the program.
- */
-void usage (char *prog)
-{
-    fprintf (stderr, "Usage: %s <ifname> <action> [extra arguments]\n", prog);
-    fprintf (stderr, "Actions:\n");
-    fprintf (stderr, "\t- start: start the pingpong experiment\n");
-    fprintf (stderr, "\t         on the server: %s <ifname> start <# of packets>\n", prog);
-    fprintf (stderr, "\t         on the client: %s <ifname> start <# of packets> <packets interval (ns)> <server IP>\n", prog);
-    fprintf (stderr, "\t- remove: remove XDP program\n");
-}
 
 struct config {
     __u32 xdp_flags;
@@ -369,9 +352,6 @@ static bool process_packet (struct xsk_socket_info *xsk,
     uint64_t receive_timestamp = get_time_ns ();
     uint8_t *pkt = xsk_umem__get_data (xsk->umem->buffer, addr);
 
-    uint8_t tmp_mac[ETH_ALEN];
-    uint32_t tmp_ip;
-
     if (len < sizeof (struct ethhdr) + sizeof (struct iphdr) + sizeof (struct pingpong_payload))
     {
         LOG (stderr, "Received packet is too small\n");
@@ -379,7 +359,6 @@ static bool process_packet (struct xsk_socket_info *xsk,
     }
 
     struct ethhdr *eth = (struct ethhdr *) pkt;
-    struct iphdr *ip = (struct iphdr *) (eth + 1);
     struct pingpong_payload *payload = packet_payload ((char *) pkt);
 
     if (eth->h_proto != htons (ETH_P_PINGPONG))
@@ -391,35 +370,36 @@ static bool process_packet (struct xsk_socket_info *xsk,
     if (payload->id >= cfg.iters)
         global_exit = true;
 
-    if (is_server)
-    {
-        //LOG (stdout, "Received ping with id %d, sending pong\n", payload->id);
-        // set ts[1] with arrival timestamp and ts[2] with send timestamp
-        payload->ts[1] = receive_timestamp;
+#if __SERVER__
+    struct iphdr *ip = (struct iphdr *) (eth + 1);
+    uint8_t tmp_mac[ETH_ALEN];
+    uint32_t tmp_ip;
 
-        // swap mac and ip addresses
-        memcpy (tmp_mac, eth->h_dest, ETH_ALEN);
-        memcpy (eth->h_dest, eth->h_source, ETH_ALEN);
-        memcpy (eth->h_source, tmp_mac, ETH_ALEN);
+    //LOG (stdout, "Received ping with id %d, sending pong\n", payload->id);
+    // set ts[1] with arrival timestamp and ts[2] with send timestamp
+    payload->ts[1] = receive_timestamp;
 
-        tmp_ip = ip->daddr;
-        ip->daddr = ip->saddr;
-        ip->saddr = tmp_ip;
+    // swap mac and ip addresses
+    memcpy (tmp_mac, eth->h_dest, ETH_ALEN);
+    memcpy (eth->h_dest, eth->h_source, ETH_ALEN);
+    memcpy (eth->h_source, tmp_mac, ETH_ALEN);
 
-        payload->ts[2] = get_time_ns ();
+    tmp_ip = ip->daddr;
+    ip->daddr = ip->saddr;
+    ip->saddr = tmp_ip;
 
-        /* Here we sent the packet out of the receive port. Note that
+    payload->ts[2] = get_time_ns ();
+
+    /* Here we sent the packet out of the receive port. Note that
          * we allocate one entry and schedule it. Your design would be
          * faster if you do batch processing/transmission */
-        xsk_send_packet (xsk, addr, len, true, false);
-        return true;// the packet is queued for transmission, so we must keep the frame
-    }
-    else
-    {
-        payload->ts[3] = receive_timestamp;
-        persistence_agent->write (persistence_agent, payload);
-        return false;// the packet has no reason to be kept
-    }
+    xsk_send_packet (xsk, addr, len, true, false);
+    return true;// the packet is queued for transmission, so we must keep the frame
+#else
+    payload->ts[3] = receive_timestamp;
+    persistence_agent->write (persistence_agent, payload);
+    return false;// the packet has no reason to be kept
+#endif
 }
 
 /**
@@ -574,21 +554,30 @@ int main (int argc __unused, char **argv __unused)
     struct xsk_umem_info *umem;
     struct xsk_socket_info *xsk_socket;
 
-    if (argc < 3)
+    bool remove = false;
+
+    cfg.ifname = NULL;
+    cfg.iters = 0;
+    char *server_ip = NULL;
+    cfg.interval = 0;
+
+#if __SERVER__
+    if (!xdp_parse_args (argc, argv, &cfg.ifname, &remove, &cfg.iters))
     {
-        usage (argv[0]);
+        xdp_print_usage (argv[0]);
         return EXIT_FAILURE;
     }
+#else
+    if (!xdp_parse_args (argc, argv, &cfg.ifname, &remove, &cfg.iters, &cfg.interval, &server_ip))
+    {
+        xdp_print_usage (argv[0]);
+        return EXIT_FAILURE;
+    }
+#endif
 
-    cfg.ifname = argv[1];
     cfg.ifindex = if_nametoindex (cfg.ifname);
-    if (cfg.ifindex == 0)
-    {
-        fprintf (stderr, "ERROR: Interface %s not found\n", cfg.ifname);
-        return EXIT_FAILURE;
-    }
 
-    if (strcmp (argv[2], "remove") == 0)
+    if (remove)
     {
         struct bpf_object *obj = read_xdp_file (filename);
         if (obj == NULL)
@@ -600,33 +589,12 @@ int main (int argc __unused, char **argv __unused)
         detach_xdp (obj, prog_name, cfg.ifindex, pinpath);
         return EXIT_SUCCESS;
     }
-    else if (strcmp (argv[2], "start") != 0)// if it's not "remove" or "start"
-    {
-        usage (argv[0]);
-        return EXIT_FAILURE;
-    }
-
-    if (argc != 4 && argc != 6)
-    {
-        usage (argv[0]);
-        return EXIT_FAILURE;
-    }
-
-    is_server = argc == 4;
-
-    cfg.iters = atoi (argv[3]);
-    char *server_ip = NULL;
-    if (!is_server)
-    {
-        cfg.interval = atol (argv[4]);
-        server_ip = argv[5];
-    }
 
     uint8_t src_mac[ETH_ALEN];
     uint32_t src_ip;
     uint8_t dest_mac[ETH_ALEN];
     uint32_t dest_ip;
-    exchange_eth_ip_addresses (cfg.ifindex, server_ip, is_server, src_mac, dest_mac, &src_ip, &dest_ip);
+    exchange_eth_ip_addresses (cfg.ifindex, server_ip, __SERVER__, src_mac, dest_mac, &src_ip, &dest_ip);
 
     struct bpf_object *obj = read_xdp_file (filename);
     if (obj == NULL)
@@ -699,11 +667,10 @@ int main (int argc __unused, char **argv __unused)
     fprintf (stdout, "Starting experiment\n");
     fflush (stdout);
 
-    if (!is_server)
-    {
+#if !__SERVER__
         persistence_agent = persistence_init (outfile, PERSISTENCE_M_MIN_MAX_LATENCY);
         initialize_client (&cfg, xsk_socket, src_mac, dest_mac, &src_ip, &dest_ip);
-    }
+#endif
 
     /* Receive and count packets than drop them */
     rx_and_process (&cfg, xsk_socket);
@@ -716,7 +683,7 @@ int main (int argc __unused, char **argv __unused)
     xsk_socket__delete (xsk_socket->xsk);
     xsk_umem__delete (umem->umem);
 
-    if (!is_server)
+    if (persistence_agent)
         persistence_agent->close (persistence_agent);
 
     return EXIT_SUCCESS;

--- a/xdp/pp_sock.c
+++ b/xdp/pp_sock.c
@@ -370,7 +370,7 @@ static bool process_packet (struct xsk_socket_info *xsk,
     if (payload->id >= cfg.iters)
         global_exit = true;
 
-#if __SERVER__
+#if SERVER
     struct iphdr *ip = (struct iphdr *) (eth + 1);
     uint8_t tmp_mac[ETH_ALEN];
     uint32_t tmp_ip;
@@ -561,7 +561,7 @@ int main (int argc __unused, char **argv __unused)
     char *server_ip = NULL;
     cfg.interval = 0;
 
-#if __SERVER__
+#if SERVER
     if (!xdp_parse_args (argc, argv, &cfg.ifname, &remove, &cfg.iters))
     {
         xdp_print_usage (argv[0]);
@@ -596,7 +596,7 @@ int main (int argc __unused, char **argv __unused)
     uint32_t src_ip;
     uint8_t dest_mac[ETH_ALEN];
     uint32_t dest_ip;
-    exchange_eth_ip_addresses (cfg.ifindex, server_ip, __SERVER__, src_mac, dest_mac, &src_ip, &dest_ip);
+    exchange_eth_ip_addresses (cfg.ifindex, server_ip, SERVER, src_mac, dest_mac, &src_ip, &dest_ip);
 
     struct bpf_object *obj = read_xdp_file (filename);
     if (obj == NULL)
@@ -669,7 +669,7 @@ int main (int argc __unused, char **argv __unused)
     fprintf (stdout, "Starting experiment\n");
     fflush (stdout);
 
-#if !__SERVER__
+#if !SERVER
         persistence_agent = persistence_init (outfile, persistence_flags);
         initialize_client (&cfg, xsk_socket, src_mac, dest_mac, &src_ip, &dest_ip);
 #endif

--- a/xdp/pp_sock.c
+++ b/xdp/pp_sock.c
@@ -568,7 +568,9 @@ int main (int argc __unused, char **argv __unused)
         return EXIT_FAILURE;
     }
 #else
-    if (!xdp_parse_args (argc, argv, &cfg.ifname, &remove, &cfg.iters, &cfg.interval, &server_ip))
+    uint32_t persistence_flags = PERSISTENCE_M_ALL_TIMESTAMPS;
+
+    if (!xdp_parse_args (argc, argv, &cfg.ifname, &remove, &cfg.iters, &cfg.interval, &server_ip, &persistence_flags))
     {
         xdp_print_usage (argv[0]);
         return EXIT_FAILURE;
@@ -668,7 +670,7 @@ int main (int argc __unused, char **argv __unused)
     fflush (stdout);
 
 #if !__SERVER__
-        persistence_agent = persistence_init (outfile, PERSISTENCE_M_MIN_MAX_LATENCY);
+        persistence_agent = persistence_init (outfile, persistence_flags);
         initialize_client (&cfg, xsk_socket, src_mac, dest_mac, &src_ip, &dest_ip);
 #endif
 

--- a/xdp/pp_sock.c
+++ b/xdp/pp_sock.c
@@ -701,7 +701,7 @@ int main (int argc __unused, char **argv __unused)
 
     if (!is_server)
     {
-        persistence_agent = persistence_init (outfile, PERSISTENCE_F_MIN_MAX_LATENCY);
+        persistence_agent = persistence_init (outfile, PERSISTENCE_M_MIN_MAX_LATENCY);
         initialize_client (&cfg, xsk_socket, src_mac, dest_mac, &src_ip, &dest_ip);
     }
 

--- a/xdp/src/args.c
+++ b/xdp/src/args.c
@@ -3,14 +3,17 @@
 #if __SERVER__
 void xdp_print_usage (char *prog)
 {
+    printf ("==== Server Program ====\n");
     printf ("Usage: %s -d <ifname> [--remove] [-p <packets>]\n", prog);
     printf ("\t-r, --remove\tRemove XDP program. Only `ifname` is required.\n");
     printf ("\t-d, --dev <ifname>\tInterface to attach XDP program to.\n");
     printf ("\t-p, --packets <packets>\tNumber of packets to process in the experiment.\n");
+    printf ("\nIf you want to run the client program, compile without -DSERVER flag.\n");
 }
 #else
 void xdp_print_usage (char *prog)
 {
+    printf ("==== Client Program ====\n");
     printf ("Usage: %s -d <ifname> [--remove] [-p <packets> -i <interval> -s <server_ip>] [-m <measurement>]\n", prog);
     printf ("\t-r, --remove\tRemove XDP program. Only `ifname` is required.\n");
     printf ("\t-d, --dev <ifname>\tInterface to attach XDP program to.\n");
@@ -18,6 +21,7 @@ void xdp_print_usage (char *prog)
     printf ("\t-i, --interval <interval>\tInterval between each packet in nanoseconds.\n");
     printf ("\t-s, --server <server_ip>\tServer IP address.\n");
     printf ("\t-m, --measurement <measurement>\tMeasurement to perform. 0: All Timestamps, 1: Min/Max latency, 2: Buckets.\n");
+    printf ("\nIf you want to run the server program, compile with -DSERVER flag.\n");
 }
 #endif
 

--- a/xdp/src/args.c
+++ b/xdp/src/args.c
@@ -11,12 +11,13 @@ void xdp_print_usage (char *prog)
 #else
 void xdp_print_usage (char *prog)
 {
-    printf ("Usage: %s -d <ifname> [--remove] [-p <packets> -i <interval> -s <server_ip>]\n", prog);
+    printf ("Usage: %s -d <ifname> [--remove] [-p <packets> -i <interval> -s <server_ip>] [-m <measurement>]\n", prog);
     printf ("\t-r, --remove\tRemove XDP program. Only `ifname` is required.\n");
     printf ("\t-d, --dev <ifname>\tInterface to attach XDP program to.\n");
     printf ("\t-p, --packets <packets>\tNumber of packets to process in the experiment.\n");
     printf ("\t-i, --interval <interval>\tInterval between each packet in nanoseconds.\n");
     printf ("\t-s, --server <server_ip>\tServer IP address.\n");
+    printf ("\t-m, --measurement <measurement>\tMeasurement to perform. 0: All Timestamps, 1: Min/Max latency, 2: Buckets.\n");
 }
 #endif
 
@@ -68,10 +69,11 @@ static struct option long_options[] = {
     {"packets", required_argument, 0, 'p'},
     {"interval", required_argument, 0, 'i'},
     {"server", required_argument, 0, 's'},
+    {"measurement", required_argument, 0, 'm'},
     {"help", no_argument, 0, 'h'},
     {0, 0, 0, 0}};
 
-bool xdp_parse_args (int argc, char **argv, char **ifname, bool *remove, uint32_t *iters, uint64_t *interval, char **server_ip)
+bool xdp_parse_args (int argc, char **argv, char **ifname, bool *remove, uint32_t *iters, uint64_t *interval, char **server_ip, uint32_t *pers_flags)
 {
     int opt;
     *iters = 0;
@@ -99,6 +101,9 @@ bool xdp_parse_args (int argc, char **argv, char **ifname, bool *remove, uint32_
             break;
         case 'h':
             return false;
+        case 'm':
+            *pers_flags = pers_measurement_to_flag (atoi (optarg));
+            break;
         default:
             return false;
         }

--- a/xdp/src/args.c
+++ b/xdp/src/args.c
@@ -1,0 +1,112 @@
+#include "args.h"
+
+#if __SERVER__
+void xdp_print_usage (char *prog)
+{
+    printf ("Usage: %s -d <ifname> [--remove] [-p <packets>]\n", prog);
+    printf ("\t-r, --remove\tRemove XDP program. Only `ifname` is required.\n");
+    printf ("\t-d, --dev <ifname>\tInterface to attach XDP program to.\n");
+    printf ("\t-p, --packets <packets>\tNumber of packets to process in the experiment.\n");
+}
+#else
+void xdp_print_usage (char *prog)
+{
+    printf ("Usage: %s -d <ifname> [--remove] [-p <packets> -i <interval> -s <server_ip>]\n", prog);
+    printf ("\t-r, --remove\tRemove XDP program. Only `ifname` is required.\n");
+    printf ("\t-d, --dev <ifname>\tInterface to attach XDP program to.\n");
+    printf ("\t-p, --packets <packets>\tNumber of packets to process in the experiment.\n");
+    printf ("\t-i, --interval <interval>\tInterval between each packet in nanoseconds.\n");
+    printf ("\t-s, --server <server_ip>\tServer IP address.\n");
+}
+#endif
+
+#if __SERVER__
+static struct option long_options[] = {
+    {"remove", no_argument, 0, 'r'},
+    {"dev", required_argument, 0, 'd'},
+    {"packets", required_argument, 0, 'p'},
+    {"help", no_argument, 0, 'h'},
+    {0, 0, 0, 0}};
+
+bool xdp_parse_args (int argc, char **argv, char **ifname, bool *remove, uint32_t *iters)
+{
+    int opt;
+    *iters = 0;
+    *remove = false;
+
+    while ((opt = getopt_long (argc, argv, "d:p:r:h", long_options, NULL)) != -1)
+    {
+        switch (opt)
+        {
+        case 'd':
+            *ifname = optarg;
+            break;
+        case 'p':
+            *iters = atoi (optarg);
+            break;
+        case 'r':
+            *remove = true;
+            break;
+        case 'h':
+            return false;
+        default:
+            return false;
+        }
+    }
+
+    if (*ifname == NULL || (!*remove && *iters == 0))
+        return false;
+
+    return true;
+}
+
+#else
+
+static struct option long_options[] = {
+    {"remove", no_argument, 0, 'r'},
+    {"dev", required_argument, 0, 'd'},
+    {"packets", required_argument, 0, 'p'},
+    {"interval", required_argument, 0, 'i'},
+    {"server", required_argument, 0, 's'},
+    {"help", no_argument, 0, 'h'},
+    {0, 0, 0, 0}};
+
+bool xdp_parse_args (int argc, char **argv, char **ifname, bool *remove, uint32_t *iters, uint64_t *interval, char **server_ip)
+{
+    int opt;
+    *iters = 0;
+    *interval = 0;
+    *remove = false;
+
+    while ((opt = getopt_long (argc, argv, "d:p:i:s:r:h", long_options, NULL)) != -1)
+    {
+        switch (opt)
+        {
+        case 'd':
+            *ifname = optarg;
+            break;
+        case 'p':
+            *iters = atoi (optarg);
+            break;
+        case 'i':
+            *interval = atoi (optarg);
+            break;
+        case 's':
+            *server_ip = optarg;
+            break;
+        case 'r':
+            *remove = true;
+            break;
+        case 'h':
+            return false;
+        default:
+            return false;
+        }
+    }
+
+    if (*ifname == NULL || (!*remove && (*iters == 0 || *interval == 0 || *server_ip == NULL)))
+        return false;
+
+    return true;
+}
+#endif

--- a/xdp/src/args.c
+++ b/xdp/src/args.c
@@ -1,6 +1,6 @@
 #include "args.h"
 
-#if __SERVER__
+#if SERVER
 void xdp_print_usage (char *prog)
 {
     printf ("==== Server Program ====\n");
@@ -25,7 +25,7 @@ void xdp_print_usage (char *prog)
 }
 #endif
 
-#if __SERVER__
+#if SERVER
 static struct option long_options[] = {
     {"remove", no_argument, 0, 'r'},
     {"dev", required_argument, 0, 'd'},

--- a/xdp/src/args.h
+++ b/xdp/src/args.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "../../common/common.h"
+#include <getopt.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void xdp_print_usage (char *prog);
+
+#if __SERVER__
+bool xdp_parse_args (int argc, char **argv, char **ifname, bool *remove, uint32_t *iters);
+#else
+bool xdp_parse_args (int argc, char **argv, char **ifname, bool *remove, uint32_t *iters, uint64_t *interval, char **server_ip);
+#endif

--- a/xdp/src/args.h
+++ b/xdp/src/args.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../../common/common.h"
+#include "../../common/persistence.h"
 #include <getopt.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -13,5 +14,5 @@ void xdp_print_usage (char *prog);
 #if __SERVER__
 bool xdp_parse_args (int argc, char **argv, char **ifname, bool *remove, uint32_t *iters);
 #else
-bool xdp_parse_args (int argc, char **argv, char **ifname, bool *remove, uint32_t *iters, uint64_t *interval, char **server_ip);
+bool xdp_parse_args (int argc, char **argv, char **ifname, bool *remove, uint32_t *iters, uint64_t *interval, char **server_ip, uint32_t *pers_flags);
 #endif

--- a/xdp/src/args.h
+++ b/xdp/src/args.h
@@ -11,7 +11,7 @@
 
 void xdp_print_usage (char *prog);
 
-#if __SERVER__
+#if SERVER
 bool xdp_parse_args (int argc, char **argv, char **ifname, bool *remove, uint32_t *iters);
 #else
 bool xdp_parse_args (int argc, char **argv, char **ifname, bool *remove, uint32_t *iters, uint64_t *interval, char **server_ip, uint32_t *pers_flags);


### PR DESCRIPTION
Changes:
- Add UDP-based baseline program with no kernel bypass which can be used as a comparison to the kernel bypass techniques.
- Create a central CMakeLists file which compiles all the subprojects. 
- Move the check of whether the machine is the server host at compile-time, through the flag `__SERVER__`. This can be a small improvement in the critical portions of code where packets are handled, avoiding useless branching and allowing the compiler to do better optimizations.
- Improve command-line arguments (#2) parsing by removing positional arguments and using option arguments. For example, instead of `./pp_poll ens1f1np1 start 1000000 10000 10.10.1.1` the CLI is `./pp_poll -d ens1f1np1 -p 1000000 -i 10000 -s 10.10.1.1`, or `./pp_poll --device ens1f1np1 --packets 1000000 --interval 10000 --server 10.10.1.1`. All programs accept an optional parameter `-m <0,1,2>` or `--measurement <0,1,2>` which specifies the kind of measurement being taken, respectively: all timestamps, only min/max latency or buckets.